### PR TITLE
feat: get script by hash

### DIFF
--- a/script.go
+++ b/script.go
@@ -1,0 +1,87 @@
+// Copyright 2022 SundaeSwap Labs, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following conditions:
+//
+// Licensed under the MIT License;
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://opensource.org/licenses/MIT
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package kugo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/SundaeSwap-finance/ogmigo/v6"
+)
+
+type Script struct {
+	Language string `json:language`
+	Script   string `json:script`
+}
+
+func (c *Client) Script(ctx context.Context, scriptHash string) (script *Script, err error) {
+	start := time.Now()
+	defer func() {
+		errStr := ""
+		if err != nil {
+			errStr = err.Error()
+		}
+		c.options.logger.Info("Script() finished",
+			ogmigo.KV("duration", time.Since(start).Round(time.Millisecond).String()),
+			ogmigo.KV("err", errStr),
+		)
+	}()
+
+	url, err := url.Parse(c.options.endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse endpoint %v: %w", c.options.endpoint, err)
+	}
+	url.Path = "/v1/script/" + scriptHash
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build request: %w", err)
+	}
+
+	req.Close = true
+	req = req.WithContext(ctx)
+
+	client := http.DefaultClient
+	client.Timeout = 5 * time.Minute
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch script: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	response := &Script{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return response, fmt.Errorf("unable to parse body %s: %w", body, err)
+	}
+	return response, nil
+}

--- a/script_test.go
+++ b/script_test.go
@@ -1,0 +1,106 @@
+// Copyright 2022 SundaeSwap Labs, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following conditions:
+//
+// Licensed under the MIT License;
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://opensource.org/licenses/MIT
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package kugo
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestClient_Scripts(t *testing.T) {
+	t.Run(
+		"Successful request and unmarshaling of response",
+		func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v1/script/4fc6bb0c93780ad706425d9f7dc1d3c5e3ddbf29ba8486dce904a5fc" {
+						response := &Script{
+							Language: "plutus:v2",
+							Script:   "8201838200581c3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe8204186482051896",
+						}
+						respBody, _ := json.Marshal(response)
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(respBody)
+					} else {
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}),
+			)
+			defer server.Close()
+
+			client := New(WithEndpoint(server.URL))
+			scriptResponse, err := client.Script(
+				context.Background(),
+				"4fc6bb0c93780ad706425d9f7dc1d3c5e3ddbf29ba8486dce904a5fc",
+			)
+			expectedResponse := &Script{
+				Language: "plutus:v2",
+				Script:   "8201838200581c3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe8204186482051896",
+			}
+			if err != nil {
+				t.Fatalf("Expected no error, got %s", err)
+			}
+			if !reflect.DeepEqual(scriptResponse, expectedResponse) {
+				t.Errorf(
+					"Expected response %v, got %v",
+					expectedResponse,
+					scriptResponse,
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"Successful request returning empty",
+		func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("null"))
+				}),
+			)
+			defer server.Close()
+
+			client := New(WithEndpoint(server.URL))
+			scriptResponse, err := client.Script(
+				context.Background(),
+				"4fc6bb0c93780ad706425d9f7dc1d3c5e3ddbf29ba8486dce904a5fc",
+			)
+			if err != nil {
+				t.Fatalf("Expected no error, got %s", err)
+			}
+			if scriptResponse != nil {
+				t.Errorf("Expected nil response, got %v", scriptResponse)
+			}
+		},
+	)
+}


### PR DESCRIPTION
Port the GetScriptByHash functionality from blinklabs-io/kupogo into a Script struct and a *Client Script(context, scriptHash) function.

Run Script to get a *Script which includes a Script (and Language).