### PR TITLE
fix: matches compatibility with ogmigo types

### DIFF
--- a/types.go
+++ b/types.go
@@ -23,18 +23,52 @@
 
 package kugo
 
-import "github.com/SundaeSwap-finance/ogmigo/ouroboros/shared"
+import (
+	"encoding/json"
+
+	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync/num"
+	"github.com/SundaeSwap-finance/ogmigo/ouroboros/shared"
+)
 
 type Match struct {
-	TransactionIndex int          `json:"transaction_index,omitempty"`
-	TransactionID    string       `json:"transaction_id,omitempty"`
-	OutputIndex      int          `json:"output_index,omitempty"`
-	Address          string       `json:"address,omitempty"`
-	DatumHash        string       `json:"datum_hash,omitempty"`
-	DatumType        string       `json:"datum_type,omitempty"`
-	Value            shared.Value `json:"value,omitempty"`
-	CreatedAt        Point        `json:"created_at,omitempty"`
-	SpentAt          Point        `json:"spent_at,omitempty"`
+	TransactionIndex int             `json:"transaction_index,omitempty"`
+	TransactionID    string          `json:"transaction_id,omitempty"`
+	OutputIndex      int             `json:"output_index,omitempty"`
+	Address          string          `json:"address,omitempty"`
+	DatumHash        string          `json:"datum_hash,omitempty"`
+	DatumType        string          `json:"datum_type,omitempty"`
+	Value            CompatibleValue `json:"value,omitempty"`
+	CreatedAt        Point           `json:"created_at,omitempty"`
+	SpentAt          Point           `json:"spent_at,omitempty"`
+}
+
+type CompatibleValue shared.Value
+
+func (c *CompatibleValue) UnmarshalJSON(data []byte) error {
+	var v shared.Value
+	err := json.Unmarshal(data, &v)
+	if err == nil {
+		*c = CompatibleValue(v)
+		return nil
+	}
+	type ValueV5 struct {
+		Coins  num.Int                    `json:"coins,omitempty"`
+		Assets map[shared.AssetID]num.Int `json:"assets"`
+	}
+	var r5 ValueV5
+	err = json.Unmarshal(data, &r5)
+	if err != nil {
+		return err
+	}
+	s := shared.Value{}
+	if r5.Coins.BigInt().BitLen() != 0 {
+		s.AddAsset(shared.CreateAdaCoin(r5.Coins))
+	}
+	for asset, coins := range r5.Assets {
+		s.AddAsset(shared.Coin{AssetId: asset, Amount: coins})
+	}
+	*c = CompatibleValue(s)
+	return nil
 }
 
 type Point struct {


### PR DESCRIPTION
Kupo still returns the old "v5" ogmigo shape for the matches data, so migrate the CompatibleValue type and custom UnmarshalJSON method to support it.