### PR TITLE
add script hash, improve kupo api coverage

### DIFF
--- a/script_test.go
+++ b/script_test.go
@@ -37,7 +37,7 @@ func TestClient_Scripts(t *testing.T) {
 			t.Parallel()
 
 			script := Script{
-				Language: "plutus:v2",
+				Language: ScriptLanguagePlutusV2,
 				Script:   "8201838200581c3c07030e36bfffe67e2e2ec09e5293d384637cd2f004356ef320f3fe8204186482051896",
 			}
 			server := NewMockServer().AddScripts(script).HTTP()

--- a/testdata/script_hash.json
+++ b/testdata/script_hash.json
@@ -1,0 +1,10 @@
+{
+  "transaction_index": 0,
+  "transaction_id": "1111111111111111111111111111111111111111111111111111111111111111",
+  "output_index": 0,
+  "address": "addr1vy3qpx09uscywhpp0ekg9zwmq2yj5vp08husfq6qyh2mpps865j6t",
+  "value": {
+    "coins": 1000000
+  },
+  "script_hash": "abc"
+}

--- a/testdata/simple.json
+++ b/testdata/simple.json
@@ -1,0 +1,13 @@
+{
+  "transaction_index": 1,
+  "transaction_id": "2222222222222222222222222222222222222222222222222222222222222222",
+  "output_index": 3,
+  "address": "addr1vy3qpx09uscywhpp0ekg9zwmq2yj5vp08husfq6qyh2mpps865j6t",
+  "value": {
+    "coins": 4000000,
+    "assets": {
+      "1220099e5e430475c219518179efc7e6c8289db028904834025d5b086": 555,
+      "289db028904834025d5b085d5b08661220099e5e430475c2195181796.08661220099e": 66
+    }
+  }
+}

--- a/types.go
+++ b/types.go
@@ -37,18 +37,19 @@ type Match struct {
 	Address          string          `json:"address,omitempty"`
 	DatumHash        string          `json:"datum_hash,omitempty"`
 	DatumType        string          `json:"datum_type,omitempty"`
-	Value            CompatibleValue `json:"value,omitempty"`
+	Value            Value           `json:"value,omitempty"`
 	CreatedAt        Point           `json:"created_at,omitempty"`
 	SpentAt          Point           `json:"spent_at,omitempty"`
+	ScriptHash       string          `json:"script_hash,omitempty"`
 }
 
-type CompatibleValue shared.Value
+type Value shared.Value
 
-func (c *CompatibleValue) UnmarshalJSON(data []byte) error {
+func (c *Value) UnmarshalJSON(data []byte) error {
 	var v shared.Value
 	err := json.Unmarshal(data, &v)
 	if err == nil {
-		*c = CompatibleValue(v)
+		*c = Value(v)
 		return nil
 	}
 	type ValueV5 struct {
@@ -67,7 +68,7 @@ func (c *CompatibleValue) UnmarshalJSON(data []byte) error {
 	for asset, coins := range r5.Assets {
 		s.AddAsset(shared.Coin{AssetId: asset, Amount: coins})
 	}
-	*c = CompatibleValue(s)
+	*c = Value(s)
 	return nil
 }
 

--- a/types.go
+++ b/types.go
@@ -39,7 +39,7 @@ type Match struct {
 	DatumType        string          `json:"datum_type,omitempty"`
 	Value            Value           `json:"value,omitempty"`
 	CreatedAt        Point           `json:"created_at,omitempty"`
-	SpentAt          Point           `json:"spent_at,omitempty"`
+	SpentAt          SpentAt         `json:"spent_at,omitempty"`
 	ScriptHash       string          `json:"script_hash,omitempty"`
 	Script           Script          `json:"script,omitempty"`
 }
@@ -76,4 +76,12 @@ func (c *Value) UnmarshalJSON(data []byte) error {
 type Point struct {
 	SlotNo     int    `json:"slot_no,omitempty"`
 	HeaderHash string `json:"header_hash,omitempty"`
+}
+
+type SpentAt struct {
+	SlotNo        int    `json:"slot_no,omitempty"`
+	HeaderHash    string `json:"header_hash,omitempty"`
+	TransactionId string `json:"transaction_id,omitempty"`
+	InputIndex    int    `json:"input_index,omitempty"`
+	Redeemer      string `json:"redeemer,omitempty"`
 }

--- a/types.go
+++ b/types.go
@@ -41,6 +41,7 @@ type Match struct {
 	CreatedAt        Point           `json:"created_at,omitempty"`
 	SpentAt          Point           `json:"spent_at,omitempty"`
 	ScriptHash       string          `json:"script_hash,omitempty"`
+	Script           Script          `json:"script,omitempty"`
 }
 
 type Value shared.Value

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,49 @@
+package kugo
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/tj/assert"
+)
+
+func Test_DecodeMatch(t *testing.T) {
+	bytes, err := ioutil.ReadFile("testdata/simple.json")
+	assert.Nil(t, err)
+
+	var match Match
+	err = json.Unmarshal(bytes, &match)
+	assert.Nil(t, err)
+
+	assert.Equal(
+		t,
+		match.TransactionIndex,
+		1,
+	)
+	assert.Equal(
+		t,
+		match.TransactionID,
+		"2222222222222222222222222222222222222222222222222222222222222222",
+	)
+	assert.Equal(
+		t,
+		match.OutputIndex,
+		3,
+	)
+}
+
+func Test_DecodeMatchScriptHash(t *testing.T) {
+	bytes, err := ioutil.ReadFile("testdata/script_hash.json")
+	assert.Nil(t, err)
+
+	var match Match
+	err = json.Unmarshal(bytes, &match)
+	assert.Nil(t, err)
+
+	assert.Equal(
+		t,
+		match.ScriptHash,
+		"abc",
+	)
+}


### PR DESCRIPTION
- add script_hash field to match record
- add script field to match record
- introduce enum for script language version
- support the additional fields on the spent_at record
- rename "CompatibleValue" to just "Value"
- support native scripts