### PR TITLE
fix: guard against nil in blake2b hash creation

### DIFF
--- a/script.go
+++ b/script.go
@@ -98,7 +98,15 @@ func (s *Script) UnmarshalJSON(data []byte) error {
 
 func (s Script) Hash() []byte {
 	scriptBytes, _ := hex.DecodeString(s.Script)
-	blake, _ := blake2b.New(224/8, nil)
+	blake, err := blake2b.New(224/8, nil)
+	if err != nil {
+		panic(
+			fmt.Sprintf(
+				"unexpected error generating empty blake2b hash: %s",
+				err,
+			),
+		)
+	}
 	switch s.Language {
 	case ScriptLanguageNative:
 		blake.Write([]byte{0x00})


### PR DESCRIPTION
This adds a guard that we will never hit, in practice. The blake2b.New function can return a nil on error, so it triggers scanners like Uber's nilaway. Adding a guard and panic here clears the alert, while effectively changing nothing since we're always creating an empty hash and that will always succeed.