### PR TITLE
fix: return early/errors on nil url

### DIFF
--- a/matches.go
+++ b/matches.go
@@ -53,6 +53,9 @@ type matchesOptions struct {
 }
 
 func (o matchesOptions) apply(url *url.URL) {
+	if url == nil {
+		return
+	}
 	qs := ""
 	// Handle the mutually exclusive spent/unspent filters
 	if o.spent && !o.unspent {
@@ -164,6 +167,9 @@ func (c *Client) Matches(ctx context.Context, filters ...MatchesFilter) (matches
 	o := matchesOptions{}
 	for _, f := range filters {
 		f(&o)
+	}
+	if url == nil {
+		return nil, fmt.Errorf("nil url returned for endpoint: %v", c.options.endpoint)
 	}
 	o.apply(url)
 


### PR DESCRIPTION
This guards against someone using a misconfigured client with an invalid URL endpoint triggering a nil pointer by returning an explicit error.