### PR TITLE
fix: use stdlib constants for http codes/methods

### DIFF
--- a/checkpoints.go
+++ b/checkpoints.go
@@ -86,7 +86,7 @@ func (c *Client) Checkpoints(
 	}
 	o.apply(endpoint)
 
-	req, err := http.NewRequest("GET", endpoint.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %w", err)
 	}

--- a/datums.go
+++ b/datums.go
@@ -65,7 +65,7 @@ func (c *Client) Datum(
 	}
 	url.Path = "/v1/datums/" + datumHash
 
-	req, err := http.NewRequest("GET", url.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return "", fmt.Errorf("unable to build request: %w", err)
 	}

--- a/matches.go
+++ b/matches.go
@@ -186,7 +186,7 @@ func (c *Client) Matches(
 
 	c.logger.Debug("finding matches", ogmigo.KV("url", url.String()))
 
-	req, err := http.NewRequest("GET", url.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build request: %w", err)
 	}

--- a/metadata.go
+++ b/metadata.go
@@ -77,7 +77,7 @@ func (c *Client) Metadata(
 		url.Path += "?transaction_id=" + txId
 	}
 
-	req, err := http.NewRequest("GET", url.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build request: %w", err)
 	}

--- a/patterns.go
+++ b/patterns.go
@@ -53,7 +53,7 @@ func (c *Client) Patterns(ctx context.Context) (matches []string, err error) {
 	}()
 
 	req, err := http.NewRequest(
-		"GET",
+		http.MethodGet,
 		fmt.Sprintf("%v/v1/patterns", c.options.endpoint),
 		nil,
 	)

--- a/script.go
+++ b/script.go
@@ -89,7 +89,7 @@ func (s *Script) UnmarshalJSON(data []byte) error {
 	case "plutus:v3":
 		s.Language = ScriptLanguagePlutusV3
 	default:
-		return fmt.Errorf("Unknown script language version: '%v'", r.Language)
+		return fmt.Errorf("unknown script language version: '%v'", r.Language)
 	}
 	s.Script = r.Script
 	return nil
@@ -151,7 +151,7 @@ func (c *Client) Script(
 	}
 	url.Path = "/v1/scripts/" + scriptHash
 
-	req, err := http.NewRequest("GET", url.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build request: %w", err)
 	}


### PR DESCRIPTION
This is a personal preference (and appeases the golangci-lint usestdlibvars linter... win:win) and is functionally equivalent.