### PR TITLE
build: go 1.24

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SundaeSwap-finance/kugo
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/SundaeSwap-finance/ogmigo/v6 v6.0.2


### PR DESCRIPTION
Go keeps a "back one version" support scheme. With 1.25.0 out, support for 1.23 is being dropped from libraries. Switch to 1.24 for builds everywhere and 1.24/1.25 for CI.